### PR TITLE
Add package.json for mip installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "urls": [
+    ["dft.py", "github:peterhinch/micropython-fourier/dft.py"],
+    ["dftclass.py", "github:peterhinch/micropython-fourier/dftclass.py"],
+    ["window.py", "github:peterhinch/micropython-fourier/window.py"],
+    ["polar.py", "github:peterhinch/micropython-fourier/polar.py"]
+  ],
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Hello Peter,

This adds a `package.json` file to allow installation using the [mip tool](https://docs.micropython.org/en/latest/reference/packages.html#installing-packages-with-mip).

Usage example:
```
import mip
mip.install('github:peterhinch/micropython-fourier')
```

Thanks for considering.

Best regards
Julian